### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 - **FastMCP Mode**: Exposes `list_chatflows` and `create_prediction` tools with minimal configuration.
 - **LowLevel Mode**: Dynamically creates tools for each chatflow or assistant, requiring descriptions for each.
 
+<a href="https://glama.ai/mcp/servers/h3cdir1w9a"><img width="380" height="200" src="https://glama.ai/mcp/servers/h3cdir1w9a/badge" alt="mcp-flowise MCP server" /></a>
+
 ## Features
 
 - **Authentication**: Interact securely with the Flowise API using Bearer tokens.


### PR DESCRIPTION
This PR adds a badge for the [mcp-flowise](https://glama.ai/mcp/servers/h3cdir1w9a) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/h3cdir1w9a"><img width="380" height="200" src="https://glama.ai/mcp/servers/h3cdir1w9a/badge" alt="mcp-flowise MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.